### PR TITLE
Fix pixel offset bug

### DIFF
--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -241,8 +241,8 @@ __global__ void kernelPixelBackprojectionFDK(const Geometry geo, float* image,co
             
             float weigth;
             float realx,realy;
-            realx=-(geo.sVoxelX+geo.dVoxelX)*0.5f  +indX*geo.dVoxelX   +xyzOffset.x;
-            realy=-(geo.sVoxelY+geo.dVoxelY)*0.5f  +indY*geo.dVoxelY   +xyzOffset.y+COR;
+            realx=-(geo.sVoxelX-geo.dVoxelX)*0.5f  +indX*geo.dVoxelX   +xyzOffset.x;
+            realy=-(geo.sVoxelY-geo.dVoxelY)*0.5f  +indY*geo.dVoxelY   +xyzOffset.y+COR;
             
             weigth=__fdividef(DSO+realy*sinalpha-realx*cosalpha,DSO);
             


### PR DESCRIPTION
Fixed a pixel offset bug in the backprojector. Have verified that the changes to reconstructions before and after the change are very very small.