### PR TITLE
Add option to use exact W weights and skip V weights 

### DIFF
--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -557,11 +557,11 @@ int voxel_backprojection(float  *  projections, Geometry geo, float* result,floa
                         
                         if (unweighted)
                         {
-                            kernelPixelBackprojectionFDK<false><<<grid,block,0,stream[dev*nStreamDevice]>>>(geoArray[img_slice*deviceCount+dev],dimage[dev],i,proj_split_size[proj_block_split],texProj[(proj_block_split%2)*deviceCount+dev]);
+                            kernelPixelBackprojectionFDK<true><<<grid,block,0,stream[dev*nStreamDevice]>>>(geoArray[img_slice*deviceCount+dev],dimage[dev],i,proj_split_size[proj_block_split],texProj[(proj_block_split%2)*deviceCount+dev]);
                         }
                         else
                         {
-                            kernelPixelBackprojectionFDK<true><<<grid,block,0,stream[dev*nStreamDevice]>>>(geoArray[img_slice*deviceCount+dev],dimage[dev],i,proj_split_size[proj_block_split],texProj[(proj_block_split%2)*deviceCount+dev]);
+                            kernelPixelBackprojectionFDK<false><<<grid,block,0,stream[dev*nStreamDevice]>>>(geoArray[img_slice*deviceCount+dev],dimage[dev],i,proj_split_size[proj_block_split],texProj[(proj_block_split%2)*deviceCount+dev]);
                         }
                     }  // END for
                     //////////////////////////////////////////////////////////////////////////////////////

--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -247,6 +247,17 @@ __global__ void kernelPixelBackprojectionFDK(const Geometry geo, float* image,co
             
             if (unweighted)
             {
+                // Get Value in the computed (U,V)
+                // indAlpha is the ABSOLUTE number of projection in the projection array (NOT the current number of projection set!)
+            
+#if IS_FOR_MATLAB_TIGRE
+                voxelColumn[colIdx]+=tex3D<float>(tex, v, u ,indAlpha+0.5f);
+#else
+                voxelColumn[colIdx]+=tex3D<float>(tex, u, v ,indAlpha+0.5f);
+#endif
+            }
+            else 
+            {
                 weigth=__fdividef(DSO+realy*sinalpha-realx*cosalpha,DSO);
 
                 weigth=__frcp_rd(weigth*weigth);
@@ -258,17 +269,6 @@ __global__ void kernelPixelBackprojectionFDK(const Geometry geo, float* image,co
                 voxelColumn[colIdx]+=tex3D<float>(tex, v, u ,indAlpha+0.5f)*weigth;
 #else
                 voxelColumn[colIdx]+=tex3D<float>(tex, u, v ,indAlpha+0.5f)*weigth;
-#endif
-            }
-            else 
-            {
-                // Get Value in the computed (U,V)
-                // indAlpha is the ABSOLUTE number of projection in the projection array (NOT the current number of projection set!)
-            
-#if IS_FOR_MATLAB_TIGRE
-                voxelColumn[colIdx]+=tex3D<float>(tex, v, u ,indAlpha+0.5f);
-#else
-                voxelColumn[colIdx]+=tex3D<float>(tex, u, v ,indAlpha+0.5f);
 #endif
             }
         }  // END iterating through column of voxels

--- a/Common/CUDA/voxel_backprojection.cu
+++ b/Common/CUDA/voxel_backprojection.cu
@@ -134,6 +134,7 @@ __constant__ float projSinCosArrayDev[5*PROJ_PER_KERNEL];
 //      Description:    Main FDK backprojection kernel
 //______________________________________________________________________________
 
+template<bool unweighted>
 __global__ void kernelPixelBackprojectionFDK(const Geometry geo, float* image,const int currProjSetNumber, const int totalNoOfProjections, cudaTextureObject_t tex)
 {
     
@@ -244,18 +245,32 @@ __global__ void kernelPixelBackprojectionFDK(const Geometry geo, float* image,co
             realx=-(geo.sVoxelX+geo.dVoxelX)*0.5f  +indX*geo.dVoxelX   +xyzOffset.x;
             realy=-(geo.sVoxelY+geo.dVoxelY)*0.5f  +indY*geo.dVoxelY   +xyzOffset.y+COR;
             
-            weigth=__fdividef(DSO+realy*sinalpha-realx*cosalpha,DSO);
-            
-            weigth=__frcp_rd(weigth*weigth);
-            
-            // Get Value in the computed (U,V) and multiply by the corresponding weigth.
-            // indAlpha is the ABSOLUTE number of projection in the projection array (NOT the current number of projection set!)
+            if (unweighted)
+            {
+                weigth=__fdividef(DSO+realy*sinalpha-realx*cosalpha,DSO);
+
+                weigth=__frcp_rd(weigth*weigth);
+
+                // Get Value in the computed (U,V) and multiply by the corresponding weigth.
+                // indAlpha is the ABSOLUTE number of projection in the projection array (NOT the current number of projection set!)
             
 #if IS_FOR_MATLAB_TIGRE
-            voxelColumn[colIdx]+=tex3D<float>(tex, v, u ,indAlpha+0.5f)*weigth;
+                voxelColumn[colIdx]+=tex3D<float>(tex, v, u ,indAlpha+0.5f)*weigth;
 #else
-            voxelColumn[colIdx]+=tex3D<float>(tex, u, v ,indAlpha+0.5f)*weigth;
+                voxelColumn[colIdx]+=tex3D<float>(tex, u, v ,indAlpha+0.5f)*weigth;
 #endif
+            }
+            else 
+            {
+                // Get Value in the computed (U,V)
+                // indAlpha is the ABSOLUTE number of projection in the projection array (NOT the current number of projection set!)
+            
+#if IS_FOR_MATLAB_TIGRE
+                voxelColumn[colIdx]+=tex3D<float>(tex, v, u ,indAlpha+0.5f);
+#else
+                voxelColumn[colIdx]+=tex3D<float>(tex, u, v ,indAlpha+0.5f);
+#endif
+            }
         }  // END iterating through column of voxels
         
     }  // END iterating through multiple projections
@@ -290,7 +305,7 @@ __global__ void kernelPixelBackprojectionFDK(const Geometry geo, float* image,co
 //      Description:    Main host function for FDK backprojection (invokes the kernel)
 //______________________________________________________________________________
 
-int voxel_backprojection(float  *  projections, Geometry geo, float* result,float const * const alphas, int nalpha, const GpuIds& gpuids)
+int voxel_backprojection(float  *  projections, Geometry geo, float* result,float const * const alphas, int nalpha, const GpuIds& gpuids, bool unweighted)
 {
     // printf("voxel_backprojection(geo.nDetector = %d, %d)\n", geo.nDetecU, geo.nDetecV);
     // printf("geo.nVoxel    = %d, %d, %d\n", geo.nVoxelX, geo.nVoxelY, geo.nVoxelZ);
@@ -540,7 +555,14 @@ int voxel_backprojection(float  *  projections, Geometry geo, float* result,floa
                         cudaMemcpyToSymbolAsync(projParamsArrayDev, projParamsArrayHost, sizeof(Point3D)*6*PROJ_PER_KERNEL,0,cudaMemcpyHostToDevice,stream[dev*nStreamDevice]);
                         cudaStreamSynchronize(stream[dev*nStreamDevice]);
                         
-                        kernelPixelBackprojectionFDK<<<grid,block,0,stream[dev*nStreamDevice]>>>(geoArray[img_slice*deviceCount+dev],dimage[dev],i,proj_split_size[proj_block_split],texProj[(proj_block_split%2)*deviceCount+dev]);
+                        if (unweighted)
+                        {
+                            kernelPixelBackprojectionFDK<false><<<grid,block,0,stream[dev*nStreamDevice]>>>(geoArray[img_slice*deviceCount+dev],dimage[dev],i,proj_split_size[proj_block_split],texProj[(proj_block_split%2)*deviceCount+dev]);
+                        }
+                        else
+                        {
+                            kernelPixelBackprojectionFDK<true><<<grid,block,0,stream[dev*nStreamDevice]>>>(geoArray[img_slice*deviceCount+dev],dimage[dev],i,proj_split_size[proj_block_split],texProj[(proj_block_split%2)*deviceCount+dev]);
+                        }
                     }  // END for
                     //////////////////////////////////////////////////////////////////////////////////////
                     // END RB code, Main reconstruction loop: go through projections (rotation angles) and backproject

--- a/Common/CUDA/voxel_backprojection.hpp
+++ b/Common/CUDA/voxel_backprojection.hpp
@@ -49,7 +49,7 @@ Codes  : https://github.com/CERN/TIGRE
 #ifndef BACKPROJECTION_HPP
 #define BACKPROJECTION_HPP
 void rollPitchYawT(Geometry geo,int i, Point3D* point);
-int  voxel_backprojection(float* projections, Geometry geo, float* result,float const * const alphas,int nalpha, const GpuIds& gpuids);
+int  voxel_backprojection(float* projections, Geometry geo, float* result,float const * const alphas,int nalpha, const GpuIds& gpuids, bool unweighted);
 void splitCTbackprojection(const GpuIds& gpuids,Geometry geo,int nalpha, unsigned int* split_image, unsigned int * split_projections);
 void eulerZYZT(Geometry geo, Point3D* point);
 void computeDeltasCube(Geometry geo,int i, Point3D* xyzorigin, Point3D* deltaX, Point3D* deltaY, Point3D* deltaZ,Point3D* S);

--- a/MATLAB/Algorithms/SART.m
+++ b/MATLAB/Algorithms/SART.m
@@ -19,6 +19,11 @@ function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,varargin)
 %                  are calculated. Default is false (weights are
 %                  calculated).
 %
+%   'exactw':      Boolean controlling whether the forwardprojection weights
+%                  are calculated using the exact volume geometry, or an 
+%                  extended geometry. Default is false (weights are
+%                  calculated using extended geometry).
+%
 %   'Init':        Describes diferent initialization techniques.
 %                  'none'     : Initializes the image to zeros (default)
 %                  'FDK'      : intializes image to FDK reconstrucition
@@ -60,7 +65,7 @@ function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,varargin)
 
 %% Deal with input parameters
 blocksize=1;
-[lambda,res,lambdared,skipV,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[lambda,res,lambdared,skipV,exactW,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
 
 measurequality=~isempty(QualMeasOpts);
 if nargout>1
@@ -83,8 +88,10 @@ end
 % Projection weight, W
 
 geoaux=geo;
-geoaux.sVoxel([1 2])=geo.sDetector([1])*1.1; % a Bit bigger, to avoid numerical division by zero (small number)
-geoaux.sVoxel(3)=max(geo.sDetector(2),geo.sVoxel(3)); % make sure lines are not cropped. One is for when image is bigger than detector and viceversa
+if ~exactW
+    geoaux.sVoxel([1 2])=geo.sDetector([1])*1.1; % a Bit bigger, to avoid numerical division by zero (small number)
+    geoaux.sVoxel(3)=max(geo.sDetector(2),geo.sVoxel(3)); % make sure lines are not cropped. One is for when image is bigger than detector and viceversa
+end
 geoaux.nVoxel=[2,2,2]'; % accurate enough?
 geoaux.dVoxel=geoaux.sVoxel./geoaux.nVoxel;
 W=Ax(ones(geoaux.nVoxel','single'),geoaux,angles,'Siddon','gpuids',gpuids);  %
@@ -243,8 +250,8 @@ end
 end
 
 
-function [lambda,res,lambdared,skipv,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,alpha,argin)
-opts=     {'lambda','init','initimg','verbose','lambda_red','skipv','qualmeas','orderstrategy','nonneg','gpuids'};
+function [lambda,res,lambdared,skipv,exactw,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,alpha,argin)
+opts=     {'lambda','init','initimg','verbose','lambda_red','skipv','exactw','qualmeas','orderstrategy','nonneg','gpuids'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -315,6 +322,12 @@ for ii=1:length(opts)
                 skipv=false;
             else
                 skipv=val;
+            end
+        case 'exactw'
+            if default
+                exactw=false;
+            else
+                exactw=val;
             end
         case 'init'
             res=[];

--- a/MATLAB/Algorithms/SART.m
+++ b/MATLAB/Algorithms/SART.m
@@ -15,6 +15,10 @@ function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,varargin)
 %   'lambda_red':   Reduction of lambda.Every iteration
 %                  lambda=lambdared*lambda. Default is 0.99
 %
+%   'skipv':       Boolean controlling whether the backprojection weights
+%                  are calculated. Default is false (weights are
+%                  calculated).
+%
 %   'Init':        Describes diferent initialization techniques.
 %                  'none'     : Initializes the image to zeros (default)
 %                  'FDK'      : intializes image to FDK reconstrucition
@@ -74,9 +78,9 @@ angles_reorder=cell2mat(alphablocks);
 if ~isfield(geo,'rotDetector')
     geo.rotDetector=[0;0;0];
 end
-%% Create weigthing matrices
+%% Create weighting matrices
 
-% Projection weigth, W
+% Projection weight, W
 
 geoaux=geo;
 geoaux.sVoxel([1 2])=geo.sDetector([1])*1.1; % a Bit bigger, to avoid numerical division by zero (small number)
@@ -88,7 +92,7 @@ W(W<min(geo.dVoxel)/4)=Inf;
 W=1./W;
 W(W>0.1)=0.1;
 
-% Back-Projection weigth, V
+% Back-Projection weight, V
 if ~skipV
     V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
 end
@@ -290,7 +294,7 @@ for ii=1:length(opts)
         case 'lambda'
             if default
                 lambda=1;
-            elseif ischar(val)&&strcmpi(val,'nesterov');
+            elseif ischar(val)&&strcmpi(val,'nesterov')
                 lambda='nesterov'; %just for lowercase/upercase
             elseif length(val)>1 || ~isnumeric( val)
                 error('TIGRE:SART:InvalidInput','Invalid lambda')
@@ -338,8 +342,8 @@ for ii=1:length(opts)
             if default
                 continue;
             end
-            if exist('initwithimage','var');
-                if isequal(size(val),geo.nVoxel');
+            if exist('initwithimage','var')
+                if isequal(size(val),geo.nVoxel')
                     res=single(val);
                 else
                     error('TIGRE:SART:InvalidInput','Invalid image for initialization');

--- a/MATLAB/Algorithms/SART.m
+++ b/MATLAB/Algorithms/SART.m
@@ -56,7 +56,7 @@ function [res,errorL2,qualMeasOut]=SART(proj,geo,angles,niter,varargin)
 
 %% Deal with input parameters
 blocksize=1;
-[lambda,res,lambdared,noV,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
+[lambda,res,lambdared,skipV,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,angles,varargin);
 
 measurequality=~isempty(QualMeasOpts);
 if nargout>1
@@ -89,7 +89,7 @@ W=1./W;
 W(W>0.1)=0.1;
 
 % Back-Projection weigth, V
-if ~noV
+if ~skipV
     V=computeV(geo,angles,alphablocks,orig_index,'gpuids',gpuids);
 end
 
@@ -151,10 +151,10 @@ for ii=1:niter
             ynesterov=res+ bsxfun(@times,1./V(:,:,jj),Atb(W(:,:,index_angles(:,jj)).*(proj(:,:,index_angles(:,jj))-Ax(res,geo,angles_reorder(:,jj),'gpuids',gpuids)),geo,angles_reorder(:,jj),'gpuids',gpuids));
             res=(1-gamma)*ynesterov+gamma*ynesterov_prev;
         else
-            if ~noV
-                res=res+lambda* Atb(W(:,:,index_angles(:,jj)).*(proj(:,:,index_angles(:,jj))-Ax(res,geo,angles_reorder(:,jj),'gpuids',gpuids)),geo,angles_reorder(:,jj),'gpuids',gpuids);
+            if skipV
+                res=res+lambda* Atb(W(:,:,index_angles(:,jj)).*(proj(:,:,index_angles(:,jj))-Ax(res,geo,angles_reorder(:,jj),'gpuids',gpuids)),geo,angles_reorder(:,jj),'unweighted','gpuids',gpuids);
             else
-                res=res+lambda* bsxfun(@times,1./V(:,:,jj),Atb(W(:,:,index_angles(:,jj)).*(proj(:,:,index_angles(:,jj))-Ax(res,geo,angles_reorder(:,jj),'gpuids',gpuids)),geo,angles_reorder(:,jj),'unweighted','gpuids',gpuids));
+                res=res+lambda* bsxfun(@times,1./V(:,:,jj),Atb(W(:,:,index_angles(:,jj)).*(proj(:,:,index_angles(:,jj))-Ax(res,geo,angles_reorder(:,jj),'gpuids',gpuids)),geo,angles_reorder(:,jj),'gpuids',gpuids));
             end
         end
         if nonneg
@@ -239,8 +239,8 @@ end
 end
 
 
-function [lambda,res,lambdared,noV,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,alpha,argin)
-opts=     {'lambda','init','initimg','verbose','lambda_red','nov','qualmeas','orderstrategy','nonneg','gpuids'};
+function [lambda,res,lambdared,skipv,verbose,QualMeasOpts,OrderStrategy,nonneg,gpuids]=parse_inputs(proj,geo,alpha,argin)
+opts=     {'lambda','init','initimg','verbose','lambda_red','skipv','qualmeas','orderstrategy','nonneg','gpuids'};
 defaults=ones(length(opts),1);
 % Check inputs
 nVarargs = length(argin);
@@ -306,11 +306,11 @@ for ii=1:length(opts)
                 end
                 lambdared=val;
             end
-        case 'nov'
+        case 'skipv'
             if default
-                noV=1;
+                skipv=false;
             else
-                noV=val;
+                skipv=val;
             end
         case 'init'
             res=[];

--- a/MATLAB/Utilities/Atb.m
+++ b/MATLAB/Utilities/Atb.m
@@ -19,7 +19,7 @@ function [ img ] = Atb( projections,geo,angles,varargin )
 %% OPtionals
 
 ptype='FDK';
-expectedProjectionTypes = {'FDK','matched'};
+expectedProjectionTypes = {'FDK','matched','unweighted'};
 acceptableOptionName = {'gpuids'};
 
 if nargin > 3

--- a/MATLAB/Utilities/cuda_interface/Atb_mex.cpp
+++ b/MATLAB/Utilities/cuda_interface/Atb_mex.cpp
@@ -78,6 +78,7 @@ void mexFunction(int  nlhs , mxArray *plhs[],
     if (nrhs != 5) {
         mexErrMsgIdAndTxt("CBCT:MEX:Atb:InvalidInput", "Wrong number of inputs provided");
     }
+    
     ////////////////////////////
     // 5th argument is array of GPU-IDs.
     GpuIds gpuids;
@@ -100,10 +101,13 @@ void mexFunction(int  nlhs , mxArray *plhs[],
      ** 4th argument is matched or un matched.
      */
     bool pseudo_matched=false; // Caled krylov, because I designed it for krylov case....
+    bool unweighted=false;
     /* copy the string data from prhs[0] into a C string input_ buf.    */
     char *krylov = mxArrayToString(prhs[3]);
     if (!strcmp(krylov,"matched")) // if its 0, they are the same
         pseudo_matched=true;
+    else if (!strcmp(krylov,"unweighted")) // if its 0, they are the same
+        unweighted=true;
 
     /*
      ** Third argument: angle of projection.
@@ -355,7 +359,7 @@ void mexFunction(int  nlhs , mxArray *plhs[],
         if (pseudo_matched){
             voxel_backprojection2(projections,geo,result,angles,nangles, gpuids);
         }else{
-            voxel_backprojection(projections,geo,result,angles,nangles, gpuids);
+            voxel_backprojection(projections,geo,result,angles,nangles, gpuids, unweighted);
         }
     }else{
         voxel_backprojection_parallel(projections,geo,result,angles,nangles, gpuids);


### PR DESCRIPTION
This PR modifies the weighting in the SART algorithm to improve performance, and accuracy. The weights used in TIGRE, `V` and `W` arrays, are introduced to compensate for the weights used in the back and forward-projection kernels, respectively.

Summary of issues and changes:
 - The weights in the back-projection are only required for FDK, but they are unnecessary in SART. If the weights are removed in the kernel, the `V` array is just equal to `1` everywhere, hence can be removed. In TIGRE, storing the full `V` array costs too much memory. Therefore, the `V` array is only stored as a "collapsed" Z-average, and then re-extended to be applied to the whole volume; this looses information, and slightly reduces output quality. With the changes in this PR, we add an option to use an "unweighted" back-projection kernel, which allows us to get rid of `V` entirely. This increases speed, decreases memory usage, and also increases accuracy. This is controlled with the new `skipv` option for `SART()`, which defaults to `false` (old behavior; backward-compatible).
 - By default, TIGRE computes an approximation of the forward-projection weights, `W`, using an extended volume. According to Ander, this was done to avoid divisions by zero. But there is already code to handle such cases anyway, hence it should not be an issue. Furthermore, using an extended volume means that we are not applying the true `W` weights. This effectively reduces the value of `lambda`, hence affects the convergence rate. With this PR, we add an option to use real volume shape, instead of the extended shape, when computing the weights. This increases output accuracy. It also reduces corner cases, where the extended volume intersects with the detector. This is controlled with the new `exactw` option for `SART()`, which defaults to `false` (old behavior; backward-compatible).
